### PR TITLE
Fixed gnome-shell version and extension version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,5 +4,6 @@
   "name": "Passwordstore manager",
   "shell-version": [
     "3.20"
-  ]
+  ],
+  "version": 1
 }

--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,6 @@
   "uuid": "passwordstore@mcat95.gmail.com",
   "name": "Passwordstore manager",
   "shell-version": [
-    "3.20.2"
+    "3.20"
   ]
 }


### PR DESCRIPTION
Hi! Thank you for creating this! I tried to install the extension from extensions.gnome.org and it failed. I tried manually and I realized metadata.json was too specific about gnome-shell version. So I changed it to 3.20 and now it works :smile: 

Also, I've added a version to the extension in the metadata file too which I think it's a good practice. Thank you again for your work!!

Un saludo!