### PR TITLE
Fixed undefined variable on disable

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -94,5 +94,5 @@ function enable() {
 }
 
 function disable() {
-  serviceManager.destroy();
+  passwordManager.destroy();
 }


### PR DESCRIPTION
I found this undefined variable that throws an error when disabling the extension
