### PR TITLE
Draft: update to support gnome 3.32

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -31,6 +31,8 @@ class PassSearchProvider {
   constructor(getPassword){
     this._results = [];
     this._getPassword = getPassword;
+    this.isRemoteProvider = false;
+    this.canLaunchSearch = false;
   }
 
   _insertResults(routes){
@@ -60,19 +62,25 @@ class PassSearchProvider {
 
   getResultMetas(results, callback, cancellable){
     const lresults = this._results;
-    callback(results.map(function(resultId){
-      return {
-        id: resultId,
-        name: lresults[resultId].name,
-        description: 'Password for '+lresults[resultId].route,
-        createIcon: function(size) {
-          return new St.Icon({
-            icon_size: size,
-            icon_name: 'dialog-password',
-          });
-        }
-      };
-    }));
+    let metas = [];
+
+    for(let id in results) {
+      if (lresults[id]) {
+        metas.push({
+          id: id,
+          name: lresults[id].name,
+          description: 'Password for '+ lresults[id].route,
+          createIcon(size) {
+            return new St.Icon({
+              icon_size: size,
+              icon_name: 'dialog-password',
+            });
+          }
+        });
+      }
+    }
+
+    callback(metas);
   }
 
   activateResult(result, terms){
@@ -80,7 +88,7 @@ class PassSearchProvider {
   }
 
   filterResults(providerResults, maxResults) {
-    return providerResults.slice(0,maxResults);
+    return providerResults.slice(0, maxResults);
   }
 };
 
@@ -181,8 +189,6 @@ function enable() {
   Main.overview.viewSelector._searchResults._registerProvider(
     searchProvider
   );
-  //Main.overview.addSearchProvider(new PassSearchProvider());
-  log("Search provider added");
 }
 
 function disable() {

--- a/extension.js
+++ b/extension.js
@@ -24,7 +24,7 @@ const getPassword = route => GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, functi
     null
   );
   return false; // Don't repeat
-}, null);
+});
 
 class IconMenuItem extends PopupMenu.PopupMenuItem {
   constructor(icon_name, text) {

--- a/extension.js
+++ b/extension.js
@@ -26,24 +26,6 @@ const getPassword = route => GLib.timeout_add(GLib.PRIORITY_DEFAULT, 100, functi
   return false; // Don't repeat
 });
 
-class IconMenuItem extends PopupMenu.PopupMenuItem {
-  constructor(icon_name, text) {
-    super(text);
-    let icon = new St.Icon({icon_name: icon_name, icon_size: 25});
-    this.actor.insert_child_at_index(icon,1);
-  }
-};
-
-class SeparatorMenuItem extends PopupMenu.PopupBaseMenuItem {
-  constructor(text) {
-    super({ reactive: false, can_focus: false});
-    this._separator = new St.Widget({ style_class: 'popup-separator-menu-item',
-                                      y_expand: true,
-                                      y_align: Clutter.ActorAlign.CENTER });
-    this.actor.add(this._separator, { expand: true });
-  }
-};
-
 class PassSearchProvider {
 
   constructor(getPassword){
@@ -142,13 +124,14 @@ class PasswordManager extends PanelMenu.Button {
 
   _draw_directory() {
     this.menu.removeAll();
-    let item = new IconMenuItem('go-up',this._current_directory);
+    let item = new PopupMenu.PopupImageMenuItem(this._current_directory, 'go-up');
+
     item.connect('activate', function() {
       this._change_dir(this._current_directory.split("/").slice(0,-2).join("/") + "/");
     }.bind(this));
 
     this.menu.addMenuItem(item);
-    this.menu.addMenuItem(new SeparatorMenuItem());
+    this.menu.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
     let fd = Gio.file_new_for_path(".password-store/"+this._current_directory);
     let enumerator = fd.enumerate_children("standard::*", 0, null);
@@ -173,13 +156,13 @@ class PasswordManager extends PanelMenu.Button {
     }).forEach(element => {
       let menuElement;
       if(element.directory) {
-        menuElement = new IconMenuItem('folder', element.name+"/");
+        menuElement = new PopupMenu.PopupImageMenuItem(element.name + '/', 'folder');
         menuElement.connect('activate', function() {
           this._change_dir(this._current_directory + element.name + "/");
         }.bind(this));
       } else {
         let name = element.name.split(".").slice(0,-1).join(".");
-        menuElement = new IconMenuItem('dialog-password',name);
+        menuElement = new PopupMenu.PopupImageMenuItem(name, 'dialog-password');
         menuElement.connect('activate', function(){
           this._getPassword(this._current_directory + name);
         }.bind(this));

--- a/extension.js
+++ b/extension.js
@@ -1,8 +1,8 @@
 const GLib = imports.gi.GLib;
 const Gio = imports.gi.Gio;
-const Lang = imports.lang;
 const Main = imports.ui.main;
 const Meta = imports.gi.Meta;
+const GObject = imports.gi.GObject;
 const PanelMenu = imports.ui.panelMenu;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
@@ -103,10 +103,10 @@ class PassSearchProvider {
 };
 
 
+let PasswordManager = GObject.registerClass(
 class PasswordManager extends PanelMenu.Button {
-
-  constructor(getPassword) {
-    super(0.0);
+  _init(getPassword) {
+    super._init(0.0, null, false);
     this._current_directory = '/';
     this._getPassword = getPassword;
 
@@ -146,6 +146,7 @@ class PasswordManager extends PanelMenu.Button {
     item.connect('activate', function() {
       this._change_dir(this._current_directory.split("/").slice(0,-2).join("/") + "/");
     }.bind(this));
+
     this.menu.addMenuItem(item);
     this.menu.addMenuItem(new SeparatorMenuItem());
 
@@ -186,7 +187,7 @@ class PasswordManager extends PanelMenu.Button {
       this.menu.addMenuItem(menuElement);
     });
   }
-};
+});
 
 let passwordManager;
 let searchProvider;
@@ -207,4 +208,4 @@ function disable() {
   Main.overview.viewSelector._searchResults._unregisterProvider(
     searchProvider
   );
-}
+};

--- a/extension.js
+++ b/extension.js
@@ -110,7 +110,7 @@ class PasswordManager extends PanelMenu.Button {
     this._current_directory = '/';
     this._getPassword = getPassword;
 
-    let popupMenu = new ScrollablePopupMenu(this.actor, St.Align.START, St.Side.TOP);
+    let popupMenu = new PopupMenu.PopupMenu(this.actor, St.Align.START, St.Side.TOP);
     this.popupMenu = popupMenu;
     this.setMenu(popupMenu);
 

--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "name": "Passwordstore manager",
   "shell-version": [
     "3.20",
-    "3.22"
+    "3.22",
+    "3.32"
   ],
   "version": 4
 }

--- a/scrollablePopupMenu.js
+++ b/scrollablePopupMenu.js
@@ -1,6 +1,5 @@
 const BoxPointer = imports.ui.boxpointer;
 const Gtk = imports.gi.Gtk;
-const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 
@@ -88,7 +87,7 @@ class ScrollablePopupMenu extends PopupMenu.PopupMenu {
     }
 
     addMenuItem(menuItem, position) {
-        this.parent(menuItem, position);
+        super.addMenuItem(menuItem, position);
         if (menuItem instanceof PopupMenu.PopupSubMenuMenuItem) {
             let menu = menuItem.menu;
             menu.connect('open-state-changed', function(item, open) {

--- a/scrollablePopupMenu.js
+++ b/scrollablePopupMenu.js
@@ -4,13 +4,11 @@ const Lang = imports.lang;
 const PopupMenu = imports.ui.popupMenu;
 const St = imports.gi.St;
 
-const ScrollablePopupMenu = new Lang.Class({
-    Name: 'ScrollablePopupMenu',
-    Extends: PopupMenu.PopupMenu,
-    bottomSection: null,
+class ScrollablePopupMenu extends PopupMenu.PopupMenu {
 
-    _init: function(sourceActor, arrowAlignment, arrowSide) {
-        PopupMenu.PopupMenuBase.prototype._init.call(this, sourceActor, 'popup-menu-content');
+    constructor(sourceActor, arrowAlignment, arrowSide) {
+        super(sourceActor, 'popup-menu-content');
+        this.bottomSection = null;
         this._arrowAlignment = arrowAlignment;
         this._arrowSide = arrowSide;
 
@@ -47,31 +45,31 @@ const ScrollablePopupMenu = new Lang.Class({
 
         this._openedSubMenu = null;
         this._childMenus = [];
-    },
+    }
 
-    _addBottomSection: function() {
+    _addBottomSection() {
         this.bottomSection = new St.BoxLayout({
             vertical: true,
             style_class: 'bottomSection'
         });
         this.boxlayout.add(this.bottomSection);
-    },
+    }
 
-    clearBottomSection: function() {
+    clearBottomSection() {
         if (this.bottomSection !== null) {
             this.bottomSection.destroy();
         }
         this._addBottomSection();
-    },
+    }
 
-    isEmpty: function() {
+    isEmpty() {
         let bottomHasVisibleChildren = this.bottomSection.get_children().some(function(child) {
             return child.visible;
         });
         return !bottomHasVisibleChildren && PopupMenu.PopupMenuBase.prototype.isEmpty.call(this);
-    },
+    }
 
-    _getHeight: function(preferred, parent_before, parent_after) {
+    _getHeight(preferred, parent_before, parent_after) {
         if ((preferred < parent_after) && (parent_before != parent_after)) {
             return preferred;
         }
@@ -87,13 +85,13 @@ const ScrollablePopupMenu = new Lang.Class({
             return preferred;
         }
         return third;
-    },
+    }
 
-    addMenuItem: function(menuItem, position) {
+    addMenuItem(menuItem, position) {
         this.parent(menuItem, position);
         if (menuItem instanceof PopupMenu.PopupSubMenuMenuItem) {
             let menu = menuItem.menu;
-            menu.connect('open-state-changed', Lang.bind(this, function(item, open) {
+            menu.connect('open-state-changed', function(item, open) {
                 if (open === true) {
                     let parent_preferred_height_before =
                         menu._parent.actor.get_preferred_height(-1)[1];
@@ -105,9 +103,9 @@ const ScrollablePopupMenu = new Lang.Class({
                     menu.actor.set_height(this._getHeight(preferred_height,
                         parent_preferred_height_before, parent_preferred_height));
                 }
-            }));
+            }.bind(this));
         }
     }
-});
+};
 
 /* vi: set expandtab tabstop=4 shiftwidth=4: */


### PR DESCRIPTION
* gnome-shell has converted most of the internal classes to ES6 classes instead of using `Lang.Class`.  
* Lang.bind is no longer necessary, we can use built in `function () { }.bind()`
* SearchProvider was broken for some reason
* ScrollablePopupMenu is busted, for now I've replaced with a regular PopupMenu
* The Icon/Separator PopupMenus are unnecessary, gnome shell provides built-in equivalents.